### PR TITLE
Changed log output to avoid localisation error on Windows platforms

### DIFF
--- a/src/multitypetree/util/MigrationModelLogger.java
+++ b/src/multitypetree/util/MigrationModelLogger.java
@@ -99,7 +99,8 @@ public class MigrationModelLogger extends BEASTObject implements Loggable {
             for (int j=0; j<migModel.getNTypes(); j++) {
                 if (i==j)
                     continue;
-                out.format("%g\t", migModel.getRateForLog(i, j));
+                out.print(migModel.getRateForLog(i, j) + "\t");
+                // out.format("%g\t", migModel.getRateForLog(i, j));
             }
         }
         


### PR DESCRIPTION
Encountered bug at Cesky Krumlov workshop. This does not affect line 95, so I propose changing 102 to use the same output method.